### PR TITLE
disable slow gui_red_console on spring-headless

### DIFF
--- a/luaui/Widgets_BA/gui_red_console.lua
+++ b/luaui/Widgets_BA/gui_red_console.lua
@@ -1,3 +1,8 @@
+-- disable as clipLine is very slow on headless
+if (Spring.GetConfigInt('Headless', 0) ~= 0) then
+   return false
+end
+
 function widget:GetInfo()
 	return {
 	name      = "Red Console", --version 4.1


### PR DESCRIPTION
sth. in clipLine() is very slow on spring-headless, so disable it.

maybe glGetTextWidth returns 1 or sth. like that?