### PR TITLE
Make beamlasers do their damage the instant the beam hits instead of …

### DIFF
--- a/gamedata/alldefs_post.lua
+++ b/gamedata/alldefs_post.lua
@@ -404,4 +404,18 @@ function ModOptions_Post (UnitDefs, WeaponDefs)
 		end
 		
 	end
+	
+	-- Make BeamLasers do their damage up front instead of over time
+	-- Do this at the end so that we don't mess up any magic math
+	for id,wDef in pairs(WeaponDefs) do
+		-- Beamlasers do damage up front
+		if wDef.beamtime ~= nil then
+			beamTimeInFrames = wDef.beamtime * 30
+			--Spring.Echo(wDef.name)
+			--Spring.Echo(beamTimeInFrames)
+			wDef.beamttl = beamTimeInFrames
+			--Spring.Echo(wDef.beamttl)
+			wDef.beamtime = 0.01		
+		end
+	end
 end


### PR DESCRIPTION
…DOT but maintain the same visual

So basically, look exactly as they do now, but instead of doing the damage over time (and in a lot of cases only about half or 1/3rd damage due to target moving or just bad engine aiming), the damage is dealt the instant the beam connects.