### PR TITLE
Reenable flanking bonus with default engine value

### DIFF
--- a/gamedata/modrules.lua
+++ b/gamedata/modrules.lua
@@ -32,7 +32,7 @@ local modrules  = {
   },
 
   flankingBonus = {
-    defaultMode = 0,  -- default: 1.  The default flankingBonusMode for units. Can be 0 - No flanking bonus. Mode 1 builds up the ability to move over time, and swings to face attacks, but does not respect the way the unit is facing. Mode 2 also can swing, but moves with the unit as it turns. Mode 3 stays with the unit as it turns and otherwise doesn't move, the ideal mode to simulate something such as tank armour.
+    defaultMode = 1,  -- default: 1.  The default flankingBonusMode for units. Can be 0 - No flanking bonus. Mode 1 builds up the ability to move over time, and swings to face attacks, but does not respect the way the unit is facing. Mode 2 also can swing, but moves with the unit as it turns. Mode 3 stays with the unit as it turns and otherwise doesn't move, the ideal mode to simulate something such as tank armour.
   },
 
   sensors = {


### PR DESCRIPTION
The default value, as used in 9.46, was 1, not 0.