### PR TITLE
Re-enable blending

### DIFF
--- a/luarules/gadgets/include/GenEnvLut.lua
+++ b/luarules/gadgets/include/GenEnvLut.lua
@@ -226,6 +226,7 @@ function GenEnvLut:Execute(saveDebug)
 					local gf = Spring.GetGameFrame()
 					gl.SaveImage(0, 0, 3, 3, string.format("envLut_%s.png", gf))
 				end
+				gl.Blending(true)
 			end)
 		gl.UseShader(0)
 		gl.Texture(7, false)


### PR DESCRIPTION
DrawWorldPreUnit callbacks in Wigdets or Gadgets expect blending to be
enabled. This fixes the texture alpha blending of the dynamic metal
spots of the map 'Techno Lands'.