### PR TITLE
Update cmd_BA_hotkeys_swap_YZ.lua

### DIFF
--- a/luaui/widgets/cmd_BA_hotkeys_swap_YZ.lua
+++ b/luaui/widgets/cmd_BA_hotkeys_swap_YZ.lua
@@ -1,6 +1,6 @@
 function widget:GetInfo()
 	return {
-		name = "BA Hotkeys -- swap YZ",
+		name = "BA Hotkeys - swap YZ",
 		desc = "Swaps Y and Z in BA Hotkeys widget" ,
 		author = "Beherith",
 		date = "23 march 2012",


### PR DESCRIPTION
the double minus confuses the widget manager and state of widget is not saved. So you need to turn it on with every game start.